### PR TITLE
Support for setting up logging method

### DIFF
--- a/smoketest/__init__.py
+++ b/smoketest/__init__.py
@@ -1,9 +1,25 @@
+def _dummy_method(*args, **kwargs):
+    " Just a dummy method that does nothing. "
+    pass
+
+
+
 class SmokeTest(object):
     _FAILED_TEST_FULL_MSG = "%(method_full_name)s %(result)s: %(msg)s"
 
-    def __init__(self):
+    def __init__(self, logging_method=_dummy_method):
+        """Construct instance of the SmokeTest class.
+
+        @param logging_method: Python method that should receive a string as a
+            parameter, and logs it for further review (or it can do whatever is
+            needs to do for that matter). Optional, with dummy method which does
+            nothing.
+
+        """
         self._status = "PASS"
         self._msg = ""
+        # We will use logging method to log failures for further failure checks.
+        self._logging_method=logging_method
 
     def failed(self):
         return self._status == "FAIL"
@@ -29,12 +45,13 @@ class SmokeTest(object):
                     getattr(self, d)()
                     if self.failed():
                         failed += 1
-                        failed_tests.append(
-                            self._FAILED_TEST_FULL_MSG % {
+                        msg = self._FAILED_TEST_FULL_MSG % {
                                 'method_full_name': method_full_name,
                                 'result': 'failed',
                                 'msg': self._msg
-                            })
+                            }
+                        failed_tests.append(msg)
+                        self._logging_method(msg)
                         self.reset()
                     else:
                         passed += 1
@@ -42,12 +59,13 @@ class SmokeTest(object):
                         self.tearDown()
                 except Exception, e:
                     errored += 1
-                    errored_tests.append(
-                        self._FAILED_TEST_FULL_MSG % {
+                    msg = self._FAILED_TEST_FULL_MSG % {
                             'method_full_name': method_full_name,
                             'result': 'errored',
                             'msg': str(e)
-                        })
+                        }
+                    errored_tests.append(msg)
+                    self._logging_method(msg)
         return run, passed, failed, errored, failed_tests, errored_tests
 
     def assertEqual(self, a, b, msg=None):

--- a/testapp/main/tests.py
+++ b/testapp/main/tests.py
@@ -8,6 +8,23 @@ from smoketest import SmokeTest
 
 
 class BasicTest(TestCase):
+
+    _EXC_MSG = 'test exception'
+    _FAIL_MSG = 'some other fail test message'
+
+    class TestWithException(SmokeTest):
+        def test_fail(self):
+            self.assertTrue(False, BasicTest._FAIL_MSG)
+        def test_with_exception(self):
+            raise Exception(BasicTest._EXC_MSG)
+        def dir(self):
+            """ Overvrite dir method so test_fail would be before
+            test_with_exception for sure.
+
+            """
+            return ['test_fail', 'test_with_exception']
+
+
     def setUp(self):
         self.c = Client()
 
@@ -58,27 +75,41 @@ class BasicTest(TestCase):
 
     def test_error(self):
         " Tests the error case (when we got exception during the smoke test). "
-        exc_msg = 'test exception'
-        fail_msg = 'some other fail test message'
-
-        class TestWithException(SmokeTest):
-            def test_fail(self):
-                self.assertTrue(False, fail_msg)
-            def test_with_exception(self):
-                raise Exception(exc_msg)
-            def dir(self):
-                """ Overvrite dir method so test_fail would be before
-                test_with_exception for sure.
-
-                """
-                return ['test_fail', 'test_with_exception']
-
-        test = TestWithException()
+        test = self.TestWithException()
         (_, _, failed, errored, _, e_tests) = test.run()
         self.assertEqual(1, failed)
         self.assertEqual(1, errored)
         self.assertEqual(errored, len(e_tests))
         self.assertIn(
-                "TestWithException.test_with_exception errored: %s" % exc_msg,
+                "TestWithException.test_with_exception errored: %s" %
+                        BasicTest._EXC_MSG,
                 e_tests[0])
-        self.assertNotIn(fail_msg, e_tests[0])
+        self.assertNotIn(BasicTest._FAIL_MSG, e_tests[0])
+
+
+    def test_logging(self):
+        " On failure and on errors, messages should be logged by setup method. "
+        _logged_msgs = []
+
+        def logger_mock(msg):
+            " Mocking the logger method for testing. "
+            _logged_msgs.append(msg)
+
+        class TestForLogging(self.TestWithException):
+            " Mocked smoke test sub-class. "
+            def __init__(self):
+                " Set up mocked logger to this SmokeTest instance. "
+                super(TestForLogging, self).__init__(logger_mock)
+
+        TestForLogging().run()
+
+        # After this, both fail and error message should be logged (should be in
+        # _looged_msgs array).
+        self.assertEqual(2, len(_logged_msgs))
+        # As stated in TestWithException, the fake test will be the first for
+        # sure.
+        self.assertIn(BasicTest._FAIL_MSG, _logged_msgs[0])
+        self.assertIn(
+                "TestForLogging.test_with_exception errored: %s" %
+                        BasicTest._EXC_MSG,
+                _logged_msgs[1])


### PR DESCRIPTION
Added support for setting up logging method which will be used in case of fails and errors (with unittest).

While using smoketest together with monitis (online service for services' monitoring), I got some alerts from monitis (meaning that the our smoketest's response didn't contain word 'PASS').
As there is no way to find out what the response was at that point (at least I don't know how to do it within monitis), I needed a way to see error and fail messages even in case when anybody else loads smoketest which fails.
So, I added a parameter in constructor of SmokeTest class which will be the logging method (it should be able to receive string message as parameter, and log it somewhere).
