### PR TITLE
only show tests for master branch on travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 django-smoketest
 ================
 
-[![Build Status](https://travis-ci.org/ccnmtl/django-smoketest.png)](https://travis-ci.org/ccnmtl/django-smoketest)
+[![Build Status](https://travis-ci.org/ccnmtl/django-smoketest.png?branch=master)](https://travis-ci.org/ccnmtl/django-smoketest)
 [![Coverage Status](https://coveralls.io/repos/github/ccnmtl/django-smoketest/badge.svg?branch=master)](https://coveralls.io/github/ccnmtl/django-smoketest?branch=master)
 
 Motivation


### PR DESCRIPTION
Instead of the latest branch, which may be failing