### PR TITLE
add tox setup for tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,10 +2,15 @@ name: build-and-test
 on: [push, workflow_dispatch]
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-          python-version: [3.6]
+          python-version: [3.8]
+          tox-env:
+            - py3-django2
+            - py3-django3
+            - py3-django4
+            - flake8
     steps:
       - uses: actions/checkout@v2
 
@@ -15,4 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Build and Test
-        run: make
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+          tox -e ${{ matrix.tox-env }}

--- a/runtests.py
+++ b/runtests.py
@@ -25,6 +25,7 @@ def main():
 
         COVERAGE_EXCLUDES_FOLDERS=['migrations'],
         ROOT_URLCONF='testapp.urls',
+        SECRET_KEY='dummy',
 
         PROJECT_APPS=[
             'smoketest',
@@ -44,6 +45,7 @@ def main():
 
     django.setup()
 
+    call_command('check')
     # Fire off the tests
     call_command('test')
 

--- a/smoketest/urls.py
+++ b/smoketest/urls.py
@@ -1,10 +1,7 @@
-try:
-    from django.conf.urls import url
-except ImportError:
-    from django.conf.urls.defaults import url
+from django.urls import path
 
 from .views import IndexView
 
 urlpatterns = [
-    url(r'^$', IndexView.as_view(), name='smoketest'),
+    path('', IndexView.as_view(), name='smoketest'),
 ]

--- a/testapp/urls.py
+++ b/testapp/urls.py
@@ -1,11 +1,8 @@
-try:
-    from django.conf.urls import include, url
-except ImportError:
-    from django.conf.urls.defaults import include, url
+from django.urls import include, path
 
 from .views import TestView
 
 urlpatterns = [
-    url('^smoketest/$', include('smoketest.urls')),
-    url('^extendable/$', TestView.as_view()),
+    path('smoketest/', include('smoketest.urls')),
+    path('extendable/', TestView.as_view()),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+envlist = py3-{django{2,3,4},flake8
+
+[flake8]
+max-complexity=8
+
+[testenv:flake8]
+deps=flake8
+commands=flake8 smoketest testapp
+
+[testenv]
+deps =
+  django2: Django >= 2.0<3.0
+  django3: Django >= 3.0<4.0
+  django4: Django >= 4.0
+	coveralls
+	coverage
+commands =
+  python runtests.py
+
+[coverage:run]
+branch = True
+parallel = True
+
+[coverage:paths]
+source =
+    smoketest


### PR DESCRIPTION
I wanted to test if there were any issues with Django 4 and noticed that `django-smoketest` didn't have a `tox` setup yet, so here it is.

* test on django 2, 3, and 4
* drop django 1.x URL imports and use `path()`