### PR TITLE
Return a 500 response code for failing tests with a JSON response

### DIFF
--- a/main/tests.py
+++ b/main/tests.py
@@ -33,7 +33,7 @@ class BasicTest(TestCase):
 
     def test_basics(self):
         response = self.c.get("/smoketest/")
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(500, response.status_code)
 
         self.assertIn("FAIL", response.content.decode('utf-8'))
         # only tests from TestFailedSmokeTests should fail
@@ -55,13 +55,13 @@ class BasicTest(TestCase):
 
     def test_extendable(self):
         response = self.c.get("/extendable/")
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(500, response.status_code)
 
     def test_json(self):
         " Testing JSON response. "
         json_content_type = 'application/json'
         response = self.c.get("/smoketest/", HTTP_ACCEPT=json_content_type)
-        self.assertEqual(response.status_code, 500)
+        self.assertEqual(500, response.status_code)
         self.assertEqual(json_content_type, response.get('Content-Type', None))
 
         response_obj = json.loads(response.content.decode('utf-8'))

--- a/main/tests.py
+++ b/main/tests.py
@@ -61,6 +61,7 @@ class BasicTest(TestCase):
         " Testing JSON response. "
         json_content_type = 'application/json'
         response = self.c.get("/smoketest/", HTTP_ACCEPT=json_content_type)
+        self.assertEqual(response.status_code, 500)
         self.assertEqual(json_content_type, response.get('Content-Type', None))
 
         response_obj = json.loads(response.content.decode('utf-8'))

--- a/smoketest/views.py
+++ b/smoketest/views.py
@@ -164,6 +164,7 @@ class IndexView(View):
                             time=(finish - start) * 1000,
                             )),
                     content_type="application/json",
+                    status=http_status,
                     )
         finally:
             # always roll back the smoketest view


### PR DESCRIPTION
* Return a 500 response code for failing tests with a JSON response. (5311be8)


* Make the argument order for assertions somewhat more consistent. (510d416)

    It's still a mixed bag, but I think this herds it in the right direction.
